### PR TITLE
UTF-8 Encoding For Glove Embedding

### DIFF
--- a/server/embedding_as_service/text/glove/__init__.py
+++ b/server/embedding_as_service/text/glove/__init__.py
@@ -123,7 +123,7 @@ class Embeddings(object):
     def load_model(self, model: str, model_path: str, max_seq_length: int):
         try:
             model_file = [f for f in os.listdir(model_path) if os.path.isfile(os.path.join(model_path, f))]
-            f = open(os.path.join(model_path, model_file[0]), 'r')
+            f = open(os.path.join(model_path, model_file[0]), 'r',encoding="utf-8")
             for line in tqdm(f):
                 split_line = line.split()
                 word = split_line[0]


### PR DESCRIPTION
**Problem Statement :** It looks like UTF-8 isn't being handled in Windows. By default , Windows uses Windows 1252 encoding , https://en.wikipedia.org/wiki/Windows-1252 

**Why does it happen**
This will cause the 'UnicodeDecodeError: 'charmap' codec can't decode byte 0x90' in Windows when you run Glove embedding and there are some UTF-8 words which windows cannot find it. Hence , the way to read the glove file is to make it explicit that it is UTF-8

**what's the fix**
To make the file opening as explicit UTF-8 to handle this in Windows. No side effect on OSX/Linux (as I've tested it both)

